### PR TITLE
feat: add advanced scoring helpers

### DIFF
--- a/promptProcessor.test.ts
+++ b/promptProcessor.test.ts
@@ -1,5 +1,9 @@
 import assert from 'assert';
-import { chunkPrompt } from './promptProcessor';
+import {
+  chunkPrompt,
+  applyTfidfWeighting,
+  scoreByGoals,
+} from './promptProcessor';
 
 const prompt = `Always use DateFormatter for ISO strings. Never format dates manually.\n\nUse the FileManager module for file imports. Validate file extensions. Avoid using raw paths.\n\nDo not make network requests in render functions. Use fetch inside effects.`;
 const chunks = chunkPrompt(prompt);
@@ -10,3 +14,28 @@ assert.deepStrictEqual(chunks, [
 ]);
 
 console.log('chunkPrompt test passed');
+
+const tfidfEntries = [
+  { chunk: 'a', embedding: [1, 0] },
+  { chunk: 'b', embedding: [1, 1] },
+];
+const weighted = applyTfidfWeighting(tfidfEntries);
+const idf1 = Math.log(3 / 2) + 1;
+assert.ok(Math.abs(weighted[0].embedding[0] - 1) < 1e-6);
+assert.ok(Math.abs(weighted[1].embedding[0] - 0.5) < 1e-6);
+assert.ok(Math.abs(weighted[1].embedding[1] - 0.5 * idf1) < 1e-6);
+
+const goalEntries = [
+  { chunk: 'safe chunk', embedding: [1, 0] },
+  { chunk: 'fast chunk', embedding: [0, 1] },
+];
+const scores = scoreByGoals(goalEntries, {
+  safe: [1, 0],
+  fast: [0, 1],
+});
+assert.strictEqual(scores[0].scores.safe, 1);
+assert.strictEqual(scores[0].scores.fast, 0);
+assert.strictEqual(scores[1].scores.safe, 0);
+assert.strictEqual(scores[1].scores.fast, 1);
+
+console.log('advanced scoring tests passed');

--- a/promptProcessor.ts
+++ b/promptProcessor.ts
@@ -40,3 +40,48 @@ export async function embedChunks(chunks: string[]) {
     embedding: entry.embedding,
   }));
 }
+
+export function applyTfidfWeighting(
+  entries: { chunk: string; embedding: number[] }[],
+): { chunk: string; embedding: number[] }[] {
+  if (entries.length === 0) return [];
+  const dim = entries[0].embedding.length;
+  const df = new Array<number>(dim).fill(0);
+
+  for (const { embedding } of entries) {
+    embedding.forEach((val, i) => {
+      if (val !== 0) df[i] += 1;
+    });
+  }
+
+  const idf = df.map((d) => Math.log((entries.length + 1) / (d + 1)) + 1);
+
+  return entries.map(({ chunk, embedding }) => {
+    const absSum = embedding.reduce((sum, v) => sum + Math.abs(v), 0);
+    const weights = embedding.map((v, i) => {
+      const tf = absSum === 0 ? 0 : Math.abs(v) / absSum;
+      return tf * idf[i];
+    });
+    return { chunk, embedding: weights };
+  });
+}
+
+export function cosineSimilarity(a: number[], b: number[]): number {
+  const dot = a.reduce((sum, v, i) => sum + v * b[i], 0);
+  const normA = Math.sqrt(a.reduce((sum, v) => sum + v * v, 0));
+  const normB = Math.sqrt(b.reduce((sum, v) => sum + v * v, 0));
+  return normA && normB ? dot / (normA * normB) : 0;
+}
+
+export function scoreByGoals(
+  entries: { chunk: string; embedding: number[] }[],
+  goals: Record<string, number[]>,
+): { chunk: string; scores: Record<string, number> }[] {
+  return entries.map(({ chunk, embedding }) => {
+    const scores: Record<string, number> = {};
+    for (const [name, goalVec] of Object.entries(goals)) {
+      scores[name] = cosineSimilarity(embedding, goalVec);
+    }
+    return { chunk, scores };
+  });
+}


### PR DESCRIPTION
## Summary
- add TF-IDF weighting over chunk embeddings
- score embeddings against named goal vectors
- cover new helpers with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68919278cbc883239d3496969d200df2