### PR TITLE
feat: add simple prompt web interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Prompt Processor</title>
+</head>
+<body>
+  <h1>Prompt Processor</h1>
+  <textarea id="prompt" rows="10" cols="80" placeholder="Enter system prompt here"></textarea><br />
+  <button id="submit">Process</button>
+  <pre id="output"></pre>
+  <script>
+    document.getElementById('submit').addEventListener('click', async () => {
+      const prompt = document.getElementById('prompt').value;
+      const response = await fetch('/process', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt })
+      });
+      const data = await response.json();
+      document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+    });
+  </script>
+</body>
+</html>

--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,25 @@
 import express from 'express';
+import path from 'path';
+import { chunkPrompt } from './promptProcessor';
 
 const app = express();
 const port = process.env.PORT || 3000;
 
+app.use(express.json({ limit: '2mb' }));
+
+app.post('/process', (req, res) => {
+  const { prompt } = req.body as { prompt?: string };
+  if (typeof prompt !== 'string') {
+    res.status(400).json({ error: 'Prompt must be provided as a string' });
+    return;
+  }
+
+  const chunks = chunkPrompt(prompt);
+  res.json({ chunks });
+});
+
 app.get('/', (_req, res) => {
-  res.send('Hello, world!');
+  res.sendFile(path.join(process.cwd(), 'index.html'));
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- expose `/process` endpoint to chunk system prompts
- add basic frontend to submit prompt text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68920f3bfbbc832391c9bcb1c45a6cc5